### PR TITLE
Allow consumer to provide Tribute version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3793,7 +3793,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3989,8 +3988,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4080,8 +4078,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "publish-package": "npm run build-lib && cd dist/ngx-tribute && npm publish"
   },
   "private": true,
+  "peerDependencies": {
+    "tributejs": ">=3.3.5"
+  },
   "dependencies": {
     "@angular/animations": "^6.1.0",
     "@angular/common": "^6.1.0",
@@ -25,7 +28,6 @@
     "@angular/router": "^6.1.0",
     "core-js": "^2.5.4",
     "rxjs": "^6.0.0",
-    "tributejs": "^3.3.5",
     "zone.js": "~0.8.26"
   },
   "devDependencies": {
@@ -46,6 +48,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "ng-packagr": "^3.0.0",
     "protractor": "~5.4.0",
+    "tributejs": "~5.0.1",
     "ts-node": "~5.0.1",
     "tsickle": ">=0.29.0",
     "tslib": "^1.9.0",


### PR DESCRIPTION
The docs describe that at least 3.3.5 of `tribute.js` is needed.

To me, this implies that we are letting the consumer provide their version of `tributejs` to this library rather than transitively including tribute like currently (likely not intentional) since it is in the `dependencies` section of the `package.json`.

This PR also has the added benefit of allowing consumer to upgrade to the latest `tributejs` version without this library having to track and update changes to `tributejs`.