### PR TITLE
Upgrade tribute to v5, add events for open/close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3793,7 +3793,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3989,8 +3988,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4080,8 +4078,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9346,9 +9343,9 @@
       "dev": true
     },
     "tributejs": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/tributejs/-/tributejs-3.3.5.tgz",
-      "integrity": "sha512-bDhWj87q5SpVPPy6UyiIT6wwIWXDsSO6Re+f2uBo1HwokulLX+x3aJJnqgckq3OQCdZQSyO1mRNQrXFr2Fpw2g=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/tributejs/-/tributejs-5.1.3.tgz",
+      "integrity": "sha512-B5CXihaVzXw+1UHhNFyAwUTMDk1EfoLP5Tj1VhD9yybZ1I8DZJEv8tZ1l0RJo0t0tk9ZhR8eG5tEsaCvRigmdQ=="
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "^6.1.0",
     "core-js": "^2.5.4",
     "rxjs": "^6.0.0",
-    "tributejs": "^3.3.5",
+    "tributejs": "^5.1.3",
     "zone.js": "~0.8.26"
   },
   "devDependencies": {

--- a/projects/ngx-tribute/package.json
+++ b/projects/ngx-tribute/package.json
@@ -5,7 +5,7 @@
     "@angular/common": ">=6.0.0 <9.0.0",
     "@angular/core": ">=6.0.0 <9.0.0",
     "@angular/forms": ">=6.0.0 <9.0.0",
-    "tributejs": "^3.3.5"
+    "tributejs": "^5.1.3"
   },
   "description": "Angular 2+ library for @mentions. Supports contenteditable and Reactive Forms.",
   "scripts": {

--- a/projects/ngx-tribute/src/lib/ngx-tribute.directive.ts
+++ b/projects/ngx-tribute/src/lib/ngx-tribute.directive.ts
@@ -20,6 +20,12 @@ export class NgxTributeDirective<T> implements OnInit, OnDestroy {
     onMentioned = new EventEmitter<string>();
 
     @Output()
+    onOpened = new EventEmitter<void>();
+
+    @Output()
+    onClosed = new EventEmitter<void>();
+
+    @Output()
     mentionItemSelected = new EventEmitter<any>();
 
     tribute: Tribute<T>;
@@ -61,6 +67,13 @@ export class NgxTributeDirective<T> implements OnInit, OnDestroy {
             if (this.control) {
                 this.control.setValue(value);
             }
+        });
+
+        this.element.nativeElement.addEventListener('tribute-active-true', ()=>{
+           this.onOpened.emit();
+        });
+        this.element.nativeElement.addEventListener('tribute-active-false', ()=>{
+           this.onClosed.emit();
         });
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,6 +25,10 @@ interface TributeValue {
         <input [ngxTribute]="options" (onMentioned)="lastMention = $event">
         Value after mention: {{ lastMention }}
 
+        <h2>Events for open/close</h2>
+        <input [ngxTribute]="options" (onOpened)="isOpen = true" (onClosed)="isOpen=false" />
+        Opened: {{isOpen?"Yes":"No"}}
+
         <h2>Retrieving the original item</h2>
         <input [ngxTribute]="advancedOptions" (mentionItemSelected)="advancedMention = $event">
         Original Item recieved from mention:
@@ -94,6 +98,7 @@ export class AppComponent {
     lastMention;
     advancedMention;
     ngModelValue;
+    isOpen = false;
     form = this.fb.group({
         control: ['']
     });


### PR DESCRIPTION
- Adds event emitters for Open and close of the mentions list. 
- Updates tribute to v5 as the events have been added later.

PS. Not sure if there are any tests that I needed to look out for, `npm test` breaks right now, but on the surface, things seem to work.